### PR TITLE
Show buttons to get to open clues even if that clue has no associated plot

### DIFF
--- a/client/src/components/player/PlayerPlot.tsx
+++ b/client/src/components/player/PlayerPlot.tsx
@@ -76,7 +76,9 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
         } else {
             return (
                 <Container fluid>
-                    <em>{clue.submittableTitle}</em>
+                    <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
+                        <Button><FaPuzzlePiece />{clue.submittableTitle}</Button>
+                    </LinkContainer>
                 </Container>
             );
         }
@@ -105,11 +107,8 @@ export const PlayerPlot = () => {
                 </Button>}
             <ListGroup>
                 {sortedClues.map(clue =>
-                    <div>
+                    <div style={{marginBottom: '37px'}}>
                         <PlotItem key={clue.tableOfContentId} clue={clue} />
-                        <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
-                            <Button><FaPuzzlePiece />{clue.submittableTitle}</Button>
-                        </LinkContainer>
                     </div>
                 )}
             </ListGroup>

--- a/client/src/components/player/PlayerPlot.tsx
+++ b/client/src/components/player/PlayerPlot.tsx
@@ -76,7 +76,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
         } else {
             return (
                 <Container fluid>
-                    No plot for <em>{clue.submittableTitle}</em>
+                    <em>{clue.submittableTitle}</em>
                 </Container>
             );
         }
@@ -105,7 +105,12 @@ export const PlayerPlot = () => {
                 </Button>}
             <ListGroup>
                 {sortedClues.map(clue =>
-                    <PlotItem key={clue.tableOfContentId} clue={clue} />
+                    <div>
+                        <PlotItem key={clue.tableOfContentId} clue={clue} />
+                        <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
+                            <Button><FaPuzzlePiece />{clue.submittableTitle}</Button>
+                        </LinkContainer>
+                    </div>
                 )}
             </ListGroup>
         </div>

--- a/client/src/components/player/PlayerPlot.tsx
+++ b/client/src/components/player/PlayerPlot.tsx
@@ -5,7 +5,7 @@ import {AdditionalContent} from "components/staff/presentation/AdditionalContent
 import {CallManager} from "./CallManager";
 import {PlayerClue, usePlayerClues} from "modules/player";
 import {SolvedPlot, UnsolvedPlot} from "modules/types";
-import {FaPuzzlePiece, FaChevronDown} from "react-icons/fa";
+import {FaPuzzlePiece, FaChevronDown, FaLocationArrow} from "react-icons/fa";
 import moment from 'moment';
 import _ from 'lodash';
 
@@ -39,7 +39,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
                                 </Row>
                                 <Row style={{justifyContent: 'center', display: 'flex'}}>
                                     <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
-                                        <Button><FaPuzzlePiece /> Puzzle</Button>
+                                        <Button>{(clue.submittableType === "Puzzle") && <FaPuzzlePiece />}{(clue.submittableType === "LocUnlock") && <FaLocationArrow />}{clue.submittableTitle}</Button>
                                     </LinkContainer>
                                 </Row>
                             </ListGroup.Item>
@@ -67,7 +67,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
                         </Row>
                         <Row style={{justifyContent: 'center', display: 'flex'}}>
                             <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
-                                <Button><FaPuzzlePiece /> Puzzle</Button>
+                                <Button>{(clue.submittableType === "Puzzle") && <FaPuzzlePiece />}{(clue.submittableType === "LocUnlock") && <FaLocationArrow />}{clue.submittableTitle}</Button>
                             </LinkContainer>
                         </Row>
                     </ListGroup.Item>
@@ -77,7 +77,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
             return (
                 <Container fluid style={{marginBottom: '37px'}}>
                     <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
-                        <Button><FaPuzzlePiece />{clue.submittableTitle}</Button>
+                        <Button>{(clue.submittableType === "Puzzle") && <FaPuzzlePiece />}{(clue.submittableType === "LocUnlock") && <FaLocationArrow />}{clue.submittableTitle}</Button>
                     </LinkContainer>
                 </Container>
             );

--- a/client/src/components/player/PlayerPlot.tsx
+++ b/client/src/components/player/PlayerPlot.tsx
@@ -20,7 +20,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
         if (solvedPlot.length > 0) {
             if (clue.submittableType === 'Plot') {
                 return (
-                        <Container fluid>
+                        <Container fluid style={{marginBottom: '37px'}}>
                             <ListGroup.Item>
                                 {clueSolveTimeAnchor}
                                 <Row style={{justifyContent: 'center', display: 'flex'}}>
@@ -31,7 +31,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
                 );
             } else {
                 return (
-                        <Container fluid>
+                        <Container fluid style={{marginBottom: '37px'}}>
                             <ListGroup.Item>
                                 {clueSolveTimeAnchor}
                                 <Row style={{justifyContent: 'center', display: 'flex'}}>                                
@@ -59,7 +59,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
             // color of the LinkContainer here. If we ever configure site-wide themes this will need to
             // get pulled into that.
             return (
-                <Container fluid>
+                <Container fluid style={{marginBottom: '37px'}}>
                     <ListGroup.Item>
                         {clueSolveTimeAnchor}
                         <Row style={{justifyContent: 'center', display: 'flex'}}>
@@ -75,7 +75,7 @@ const PlotItem = ({clue}: {clue: PlayerClue}) => {
             );
         } else {
             return (
-                <Container fluid>
+                <Container fluid style={{marginBottom: '37px'}}>
                     <LinkContainer to={`/player/clue/${clue.tableOfContentId}`} style={{ color: "#FFFFFF" }}>
                         <Button><FaPuzzlePiece />{clue.submittableTitle}</Button>
                     </LinkContainer>
@@ -107,7 +107,7 @@ export const PlayerPlot = () => {
                 </Button>}
             <ListGroup>
                 {sortedClues.map(clue =>
-                    <div style={{marginBottom: '37px'}}>
+                    <div>
                         <PlotItem key={clue.tableOfContentId} clue={clue} />
                     </div>
                 )}


### PR DESCRIPTION
Game-Control frontend currently shows the text "No plot available for [title]" if a team has an unsolved clue node that has no associated UnsolvedPlot content. This PR replaces that text with a button linking to the submittable's page