### PR TITLE
Revert bootstrap upgrade until we're prepared to migrate to a newer version

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,7 @@
         "@testing-library/react": "^11.2.5",
         "@testing-library/user-event": "^12.7.1",
         "axios": "^0.28.0",
-        "bootstrap": "^5.0.0",
+        "bootstrap": "^4.6.0",
         "history": "^4.7.2",
         "humanize-duration": "^3.23.1",
         "jquery": "^3.5.1",
@@ -6218,9 +6218,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
       "funding": [
         {
           "type": "github",
@@ -6232,7 +6232,8 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
       }
     },
     "node_modules/brace-expansion": {
@@ -27434,9 +27435,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.7.1",
     "axios": "^0.28.0",
-    "bootstrap": "^5.0.0",
+    "bootstrap": "^4.6.0",
     "history": "^4.7.2",
     "humanize-duration": "^3.23.1",
     "jquery": "^3.5.1",


### PR DESCRIPTION
dependabot upgraded us to 5, but the styling is very different there and we'll need to also update react-bootstrap to ensure everything is consistent.