### PR TITLE
fix clue answer groupings and adding unlocks to grouped answers

### DIFF
--- a/client/src/components/staff/presentation/PuzzleAnswersList.tsx
+++ b/client/src/components/staff/presentation/PuzzleAnswersList.tsx
@@ -171,8 +171,8 @@ const PuzzleAnswersList = ({ clue }: Props) => {
 
     const renderGroupUnlocks = (groupedAnswer: GroupedAnswer) => {
         const unlockableClues = cluesModule.data.filter(
-            (clue) =>
-                clue.tableOfContentId !== clue.tableOfContentId && groupedAnswer.unlockedClues.find((unlock) => unlock.tableOfContentId === clue.tableOfContentId) === undefined
+            (nextClue) =>
+                nextClue.tableOfContentId !== clue.tableOfContentId && groupedAnswer.unlockedClues.find((unlock) => unlock.tableOfContentId === nextClue.tableOfContentId) === undefined
         );
 
         if (groupedAnswer.unlockedClues !== null) {

--- a/client/src/modules/staff/index.ts
+++ b/client/src/modules/staff/index.ts
@@ -220,7 +220,7 @@ export const compareAnswers = (answer1: Answer, answer2: Answer) => {
         return compareTextResult;
     }
 
-    if (answer1.teamId !== undefined && answer2.teamId !== undefined) {
+    if (answer1.teamId !== undefined && answer2.teamId !== undefined && answer1.teamId !== null && answer2.teamId !== null) {
         const compareTeamIdResult = answer1.teamId.localeCompare(answer2.teamId);
         if (compareTeamIdResult !== 0) {
             return compareTeamIdResult;


### PR DESCRIPTION
Team IDs for singleton answers come in as `null`, not `undefined`

Also fix the `clue` variable shadowing that was preventing the unlock dropdown from populating on grouped answers