### PR TITLE
Add a new optional concept of a default response

### DIFF
--- a/client/src/components/player/PlayerClueDetails.tsx
+++ b/client/src/components/player/PlayerClueDetails.tsx
@@ -73,7 +73,7 @@ const Submission = ({ submission, teamId, playerId }: { submission: PlayerSubmis
         listGroupItemType = 'danger';
     }
 
-    const displayResponse = submission.answerResponse || submission.defaultIncorrectResponse;
+    const displayResponse = submission.answerResponse ?? submission.defaultIncorrectResponse;
 
     return (
         <ListGroupItem key={submission.submissionId} variant={listGroupItemType}>

--- a/client/src/components/player/PlayerClueDetails.tsx
+++ b/client/src/components/player/PlayerClueDetails.tsx
@@ -73,11 +73,13 @@ const Submission = ({ submission, teamId, playerId }: { submission: PlayerSubmis
         listGroupItemType = 'danger';
     }
 
+    const displayResponse = submission.answerResponse || submission.defaultIncorrectResponse;
+
     return (
         <ListGroupItem key={submission.submissionId} variant={listGroupItemType}>
             {submission.isHidden ? <h5>You successfully solved this puzzle</h5> : <h5>{submission.submission}</h5>}
             <div>
-                <small>{submission.answerResponse}</small>
+                <small>{displayResponse}</small>
             </div>
             <div>
                 <small>{moment.utc(submission.submissionTime).fromNow()}</small>

--- a/client/src/components/staff/StaffClueDetails.tsx
+++ b/client/src/components/staff/StaffClueDetails.tsx
@@ -168,17 +168,17 @@ const StaffClueDetails = () => {
                                 />
                             )}
                         />
-                        <PuzzleAnswersList clue={foundClue} />
                         {foundClue.defaultIncorrectResponse ? (
-                            <div className="mt-2 p-2 border rounded bg-light">
+                            <div className="mt-2 mb-2 p-2 border rounded bg-light">
                                 <strong>Default response for unrecognized answers:</strong>{' '}
                                 <em>{foundClue.defaultIncorrectResponse}</em>
                             </div>
                         ) : (
-                            <div className="mt-2 text-muted">
+                            <div className="mt-2 mb-2 text-muted">
                                 <small>No default response configured for unrecognized answers. Edit the puzzle to add one.</small>
                             </div>
                         )}
+                        <PuzzleAnswersList clue={foundClue} />
                     </Tab>
                     <Tab eventKey={4} title="Logistics">
                         <ClueLogistics clue={foundClue} />

--- a/client/src/components/staff/StaffClueDetails.tsx
+++ b/client/src/components/staff/StaffClueDetails.tsx
@@ -169,6 +169,16 @@ const StaffClueDetails = () => {
                             )}
                         />
                         <PuzzleAnswersList clue={foundClue} />
+                        {foundClue.defaultIncorrectResponse ? (
+                            <div className="mt-2 p-2 border rounded bg-light">
+                                <strong>Default response for unrecognized answers:</strong>{' '}
+                                <em>{foundClue.defaultIncorrectResponse}</em>
+                            </div>
+                        ) : (
+                            <div className="mt-2 text-muted">
+                                <small>No default response configured for unrecognized answers. Edit the puzzle to add one.</small>
+                            </div>
+                        )}
                     </Tab>
                     <Tab eventKey={4} title="Logistics">
                         <ClueLogistics clue={foundClue} />

--- a/client/src/components/staff/StaffClueDetails.tsx
+++ b/client/src/components/staff/StaffClueDetails.tsx
@@ -171,7 +171,7 @@ const StaffClueDetails = () => {
                         {foundClue.defaultIncorrectResponse ? (
                             <div className="mt-2 mb-2 p-2 border rounded bg-light">
                                 <strong>Default response for unrecognized answers:</strong>{' '}
-                                <em>{foundClue.defaultIncorrectResponse}</em>
+                                <em style={{ whiteSpace: 'pre-wrap', display: 'block' }}>{foundClue.defaultIncorrectResponse}</em>
                             </div>
                         ) : (
                             <div className="mt-2 mb-2 text-muted">

--- a/client/src/components/staff/dialogs/ClueForm.tsx
+++ b/client/src/components/staff/dialogs/ClueForm.tsx
@@ -22,6 +22,7 @@ export const ClueForm = ({ clue, onSubmit, onComplete }: Props) => {
     const [parTime, setParTime] = useState(clue?.parSolveTime?.toString() ?? '0');
     const [openTime, setOpenTime] = useState<moment.Moment | undefined>(clue?.openTime);
     const [closingTime, setClosingTime] = useState<moment.Moment | undefined>(clue?.closingTime);
+    const [defaultIncorrectResponse, setDefaultIncorrectResponse] = useState(clue?.defaultIncorrectResponse ?? '');
 
     const isTitleValid = () => title.length > 0;
     const isSortOrderValid = () => !isNaN(parseInt(sortOrder));
@@ -86,6 +87,19 @@ export const ClueForm = ({ clue, onSubmit, onComplete }: Props) => {
                 <Form.Control type="text" isInvalid={!isParTimeValid()} value={parTime} placeholder="Par Time" onChange={(event) => setParTime(event.target.value)} />
                 <Form.Control.Feedback type="invalid">Par Time must be an integer</Form.Control.Feedback>
             </Form.Group>
+            <Form.Group>
+                <Form.Label>Default Incorrect Response</Form.Label>
+                <Form.Control
+                    as="textarea"
+                    rows={2}
+                    value={defaultIncorrectResponse}
+                    placeholder="Optional message shown when a player submits an unrecognized answer"
+                    onChange={(event) => setDefaultIncorrectResponse(event.target.value)}
+                />
+                <Form.Text className="text-muted">
+                    Leave blank to show no message for unrecognized answers.
+                </Form.Text>
+            </Form.Group>
             <Button
                 disabled={!isSortOrderValid()}
                 onClick={() => {
@@ -97,6 +111,7 @@ export const ClueForm = ({ clue, onSubmit, onComplete }: Props) => {
                         takeOver,
                         submittableType,
                         parTime: parseInt(parTime),
+                        defaultIncorrectResponse: defaultIncorrectResponse || undefined,
                     });
                     onComplete();
                 }}

--- a/client/src/components/staff/dialogs/ClueForm.tsx
+++ b/client/src/components/staff/dialogs/ClueForm.tsx
@@ -111,7 +111,7 @@ export const ClueForm = ({ clue, onSubmit, onComplete }: Props) => {
                         takeOver,
                         submittableType,
                         parTime: parseInt(parTime),
-                        defaultIncorrectResponse: defaultIncorrectResponse || undefined,
+                        defaultIncorrectResponse: defaultIncorrectResponse.trim() || undefined,
                     });
                     onComplete();
                 }}

--- a/client/src/components/staff/puzzleDetails/ClueLogistics.tsx
+++ b/client/src/components/staff/puzzleDetails/ClueLogistics.tsx
@@ -7,11 +7,19 @@ type Props = Readonly<{
 }>;
 
 export const ClueLogistics = ({ clue }: Props) => {
+    const hasTimingData = !!clue.openTime || !!clue.closingTime || !!clue.parSolveTime;
+
     return (
         <div>
-            {!!clue.openTime && <div>Puzzle opens at {moment.utc(clue.openTime).local().format('dddd HH:mm')}</div>}
-            {!!clue.closingTime && <div>Puzzle closes at {moment.utc(clue.closingTime).local().format('dddd HH:mm')}</div>}
-            {!!clue.parSolveTime && <div>Expected solve time is {clue.parSolveTime} minutes</div>}
+            {hasTimingData ? (
+                <>
+                    {!!clue.openTime && <div>Puzzle opens at {moment.utc(clue.openTime).local().format('dddd HH:mm')}</div>}
+                    {!!clue.closingTime && <div>Puzzle closes at {moment.utc(clue.closingTime).local().format('dddd HH:mm')}</div>}
+                    {!!clue.parSolveTime && <div>Expected solve time is {clue.parSolveTime} minutes</div>}
+                </>
+            ) : (
+                <div className="text-muted">No timing data is configured for this puzzle.</div>
+            )}
         </div>
     );
 };

--- a/client/src/modules/staff/clues/models.ts
+++ b/client/src/modules/staff/clues/models.ts
@@ -33,6 +33,7 @@ export type StaffClue = Readonly<{
     closingTime?: Moment;
     ratings: ClueRating[];
     instances: ClueInstance[];
+    defaultIncorrectResponse?: string;
 }>;
 
 export type StaffClueTemplate = Readonly<{
@@ -46,6 +47,7 @@ export type StaffClueTemplate = Readonly<{
     openTime?: Moment;
     closingTime?: Moment;
     parTime?: number;
+    defaultIncorrectResponse?: string;
 }>;
 
 export type ContentTemplate = Readonly<{

--- a/client/src/modules/staff/clues/staffCluesModule.ts
+++ b/client/src/modules/staff/clues/staffCluesModule.ts
@@ -37,6 +37,7 @@ function updateClueDetails(initialClues: StaffClue[], updatedClue: StaffClue) {
                       ratings: updatedClue.ratings,
                       content: updatedClue.content,
                       instances: updatedClue.instances,
+                      defaultIncorrectResponse: updatedClue.defaultIncorrectResponse,
                   }
                 : clue;
         });
@@ -95,6 +96,7 @@ function updateToc(currentClues: StaffClue[], updatedToc: StaffClue) {
                 openTime: updatedToc.openTime,
                 closingTime: updatedToc.closingTime,
                 parSolveTime: updatedToc.parSolveTime,
+                defaultIncorrectResponse: updatedToc.defaultIncorrectResponse,
                 shortTitle: updatedToc.shortTitle,
                 submittableId: updatedToc.submittableId,
                 submittableTitle: updatedToc.submittableTitle,
@@ -126,6 +128,7 @@ function updateToc(currentClues: StaffClue[], updatedToc: StaffClue) {
                     openTime: updatedToc.openTime,
                     closingTime: updatedToc.closingTime,
                     parSolveTime: updatedToc.parSolveTime,
+                    defaultIncorrectResponse: updatedToc.defaultIncorrectResponse,
                     submittableType: updatedToc.submittableType,
                     instances: updatedToc.instances,
                 };

--- a/client/src/modules/types/models.ts
+++ b/client/src/modules/types/models.ts
@@ -62,6 +62,7 @@ export type PlayerSubmission = Readonly<{
     submissionTime: Moment;
     isCorrectAnswer: boolean;
     isHidden: boolean;
+    defaultIncorrectResponse?: string;
     unlockedClues?: UnlockedClue[];
     unlockedAchievements: Achievement[];
     additionalContent?: Content;

--- a/database/gamecontrol.sql
+++ b/database/gamecontrol.sql
@@ -253,7 +253,7 @@ SELECT
     dbo.Submission.Submission,
     dbo.Submittable.SubmittableId,
     dbo.Submission.SubmissionTime,
-    dbo.Answer.AnswerResponse,
+    ISNULL(dbo.Answer.AnswerResponse, dbo.TableOfContentsEntry.DefaultIncorrectResponse) AS AnswerResponse,
     ISNULL(dbo.Answer.IsCorrectAnswer, 0) AS IsCorrectAnswer,
     dbo.Team.TeamId,
     dbo.Answer.AnswerId,
@@ -266,6 +266,8 @@ SELECT
 FROM dbo.Submittable
 INNER JOIN dbo.Submission ON dbo.Submission.Submittable = dbo.Submittable.SubmittableId
 INNER JOIN dbo.Team ON dbo.Team.TeamId = dbo.Submission.Team
+INNER JOIN dbo.TableOfContentsEntry ON dbo.TableOfContentsEntry.Submittable = dbo.Submittable.SubmittableId
+    AND dbo.TableOfContentsEntry.EventInstance = dbo.Team.EventInstance
 LEFT OUTER JOIN dbo.Answer ON dbo.Answer.Submittable = dbo.Submittable.SubmittableId 
             AND dbo.Answer.AnswerText = dbo.Submission.Submission COLLATE Latin1_General_100_CI_AS_SC
             AND dbo.Team.EventInstance = dbo.Answer.EventInstance
@@ -426,6 +428,7 @@ CREATE TABLE [dbo].[TableOfContentsEntry](
     [OpenTime] [datetime] NULL,
     [ClosingTime] [datetime] NULL,
     [ParSolveTime] [int] NULL,
+    [DefaultIncorrectResponse] [nvarchar](max) NULL,
  CONSTRAINT [PK_TableOfContentsEntry] PRIMARY KEY CLUSTERED 
 (
     [TableOfContentId] ASC
@@ -2459,7 +2462,7 @@ RETURN (
         dbo.Submission.Submission,
         dbo.Submittable.SubmittableId,
         dbo.Submission.SubmissionTime,
-        dbo.Answer.AnswerResponse,
+        ISNULL(dbo.Answer.AnswerResponse, dbo.TableOfContentsEntry.DefaultIncorrectResponse) AS AnswerResponse,
         ISNULL(dbo.Answer.IsCorrectAnswer, 0) AS IsCorrectAnswer,
         dbo.Submission.Team as TeamId,
         dbo.Answer.AnswerId,
@@ -2473,6 +2476,8 @@ RETURN (
     FROM Submission
     INNER JOIN Submittable on Submittable.SubmittableId = Submission.Submittable
     INNER JOIN Team on Submission.Team = Team.TeamId AND Team.EventInstance = @eventInstance
+    INNER JOIN dbo.TableOfContentsEntry ON dbo.TableOfContentsEntry.Submittable = dbo.Submittable.SubmittableId
+        AND dbo.TableOfContentsEntry.EventInstance = @eventInstance
     LEFT OUTER JOIN Participation on Participation.ParticipationId = Submission.Participation AND Participation.EventInstance = @eventInstance
     LEFT OUTER JOIN Participant on Participant.ParticipantId = Participation.Participant
     LEFT OUTER JOIN dbo.Answer ON
@@ -2813,7 +2818,8 @@ BEGIN
 		   TableOfContentsEntry.SortOrder,
 		   TableOfContentsEntry.OpenTime,
 		   TableOfContentsEntry.ClosingTime,
-		   TableOfContentsEntry.ParSolveTime
+		   TableOfContentsEntry.ParSolveTime,
+		   TableOfContentsEntry.DefaultIncorrectResponse
 	FROM TableOfContentsEntry
 	INNER JOIN Submittable ON Submittable.SubmittableId = TableOfContentsEntry.Submittable
 	WHERE TableOfContentsEntry.EventInstance = @eventInstance

--- a/database/gamecontrol.sql
+++ b/database/gamecontrol.sql
@@ -253,7 +253,7 @@ SELECT
     dbo.Submission.Submission,
     dbo.Submittable.SubmittableId,
     dbo.Submission.SubmissionTime,
-    ISNULL(dbo.Answer.AnswerResponse, dbo.TableOfContentsEntry.DefaultIncorrectResponse) AS AnswerResponse,
+    dbo.Answer.AnswerResponse,
     ISNULL(dbo.Answer.IsCorrectAnswer, 0) AS IsCorrectAnswer,
     dbo.Team.TeamId,
     dbo.Answer.AnswerId,
@@ -262,7 +262,8 @@ SELECT
     dbo.Answer.AppliesToTeam,
     dbo.Answer.AdditionalContent,
     dbo.Answer.EventInstance,
-    ISNULL(dbo.Answer.IsHidden, 0) AS IsHidden
+    ISNULL(dbo.Answer.IsHidden, 0) AS IsHidden,
+    dbo.TableOfContentsEntry.DefaultIncorrectResponse
 FROM dbo.Submittable
 INNER JOIN dbo.Submission ON dbo.Submission.Submittable = dbo.Submittable.SubmittableId
 INNER JOIN dbo.Team ON dbo.Team.TeamId = dbo.Submission.Team
@@ -2462,7 +2463,7 @@ RETURN (
         dbo.Submission.Submission,
         dbo.Submittable.SubmittableId,
         dbo.Submission.SubmissionTime,
-        ISNULL(dbo.Answer.AnswerResponse, dbo.TableOfContentsEntry.DefaultIncorrectResponse) AS AnswerResponse,
+        dbo.Answer.AnswerResponse,
         ISNULL(dbo.Answer.IsCorrectAnswer, 0) AS IsCorrectAnswer,
         dbo.Submission.Team as TeamId,
         dbo.Answer.AnswerId,
@@ -2472,7 +2473,8 @@ RETURN (
         dbo.Answer.AppliesToTeam,
         dbo.Answer.AdditionalContent,
         dbo.Answer.EventInstance,
-        ISNULL(dbo.Answer.IsHidden, 0) AS IsHidden
+        ISNULL(dbo.Answer.IsHidden, 0) AS IsHidden,
+        dbo.TableOfContentsEntry.DefaultIncorrectResponse
     FROM Submission
     INNER JOIN Submittable on Submittable.SubmittableId = Submission.Submittable
     INNER JOIN Team on Submission.Team = Team.TeamId AND Team.EventInstance = @eventInstance

--- a/server/Controllers/Staff/StaffPuzzlesController.cs
+++ b/server/Controllers/Staff/StaffPuzzlesController.cs
@@ -223,7 +223,8 @@ namespace GameControl.Server.Controllers
                         TakeOver = newClue.TakeOver,
                         OpenTime = newClue.OpenTime,
                         ClosingTime = newClue.ClosingTime,
-                        ParSolveTime = newClue.ParTime
+                        ParSolveTime = newClue.ParTime,
+                        DefaultIncorrectResponse = newClue.DefaultIncorrectResponse,
                     };
 
                     this.dbContext.TableOfContentsEntry.Add(newToc);
@@ -270,6 +271,7 @@ namespace GameControl.Server.Controllers
                     toc.OpenTime = newClue.OpenTime;
                     toc.ClosingTime = newClue.ClosingTime;
                     toc.ParSolveTime = newClue.ParTime;
+                    toc.DefaultIncorrectResponse = newClue.DefaultIncorrectResponse;
 
                     this.dbContext.TableOfContentsEntry.Update(toc);
                     this.dbContext.Submittable.Update(submittable);

--- a/server/Database/SprocTypes/TableOfContentsEntryForStaff.cs
+++ b/server/Database/SprocTypes/TableOfContentsEntryForStaff.cs
@@ -27,5 +27,7 @@ namespace GameControl.Server.Database.SprocTypes
         public DateTime? ClosingTime { get; set; }
 
         public int? ParSolveTime { get; set; }
+
+        public string DefaultIncorrectResponse { get; set; }
     }
 }

--- a/server/Database/Tables/TableOfContentsEntry.cs
+++ b/server/Database/Tables/TableOfContentsEntry.cs
@@ -23,5 +23,7 @@ namespace GameControl.Server.Database.Tables
         public DateTime? ClosingTime { get; set; }
 
         public int? ParSolveTime { get; set; }
+
+        public string DefaultIncorrectResponse { get; set; }
     }
 }

--- a/server/Database/Tables/ValidSubmission.cs
+++ b/server/Database/Tables/ValidSubmission.cs
@@ -31,5 +31,7 @@ namespace GameControl.Server.Database.Tables
         public Guid? AppliesToTeam { get; set; }
 
         public Guid? AdditionalContent { get; set; }
+
+        public string DefaultIncorrectResponse { get; set; }
     }
 }

--- a/server/RequestTypes/Staff/ClueTemplate.cs
+++ b/server/RequestTypes/Staff/ClueTemplate.cs
@@ -23,5 +23,7 @@ namespace GameControl.Server.RequestTypes.Staff
         public DateTime? ClosingTime { get; set; }
 
         public int? ParTime { get; set; }
+
+        public string DefaultIncorrectResponse { get; set; }
     }
 }

--- a/server/ViewModel/Staff/StaffClueViewModel.cs
+++ b/server/ViewModel/Staff/StaffClueViewModel.cs
@@ -15,6 +15,7 @@ namespace GameControl.Server.ViewModel.Staff
             this.ParSolveTime = toc.ParSolveTime;
             this.OpenTime = toc.OpenTime;
             this.ClosingTime = toc.ClosingTime;
+            this.DefaultIncorrectResponse = toc.DefaultIncorrectResponse;
             this.TeamsStatus = new List<SolveDataViewModel>();
             this.Answers = new List<AnswerViewModel>();
         }
@@ -33,6 +34,7 @@ namespace GameControl.Server.ViewModel.Staff
             ParSolveTime = tocForStaff.ParSolveTime;
             OpenTime = tocForStaff.OpenTime;
             ClosingTime = tocForStaff.ClosingTime;
+            DefaultIncorrectResponse = tocForStaff.DefaultIncorrectResponse;
         }
 
         public string ShortTitle { get; set; }
@@ -42,6 +44,8 @@ namespace GameControl.Server.ViewModel.Staff
         public DateTime? OpenTime { get; set; }
 
         public DateTime? ClosingTime { get; set; }
+
+        public string DefaultIncorrectResponse { get; set; }
 
         public int? AverageSolveTime { get; set; }
 

--- a/server/ViewModel/SubmissionViewModel.cs
+++ b/server/ViewModel/SubmissionViewModel.cs
@@ -33,6 +33,7 @@ namespace GameControl.Server.ViewModel
             this.UnlockedTocs = new List<UnlockedInfo>();
             this.UnlockedAchievements = new List<AchievementViewModel>();
             this.AdditionalContentId = dbSubmission.AdditionalContent;
+            this.DefaultIncorrectResponse = dbSubmission.DefaultIncorrectResponse;
         }
 
         public Guid SubmissionId { get; set; }
@@ -52,6 +53,8 @@ namespace GameControl.Server.ViewModel
         public bool IsCorrectAnswer { get; set; }
 
         public bool IsHidden { get; set; }
+
+        public string DefaultIncorrectResponse { get; set; }
 
         public List<UnlockedInfo> UnlockedTocs { get; set; }
 


### PR DESCRIPTION
This adds a new feature to enable having a default response to answers, for example recommending that they consult with GC, outside of specific partials.

When creating puzzles this is a new field at the bottom of the form:
<img width="578" height="238" alt="image" src="https://github.com/user-attachments/assets/c6e60375-a8bc-466a-bb9c-0f5270d19501" />

On the staff/puzzle answers tab, if there is not an option set, it has a default state:
<img width="551" height="118" alt="image" src="https://github.com/user-attachments/assets/be0476b2-d9e8-4247-84e3-6c5f587577a0" />

If one is configured it shows up on the answers page below the list of answers:
<img width="585" height="284" alt="image" src="https://github.com/user-attachments/assets/ed8ed934-8ae1-4990-b3e9-8e293e285f26" />

Teams will see it as a partial - I have a conversation with Bridgette whether that's desired or whether we need to make further changes for it to be badged as incorrect:
<img width="691" height="424" alt="image" src="https://github.com/user-attachments/assets/0c9b5702-49f5-4201-9ca8-8d1eefa94963" />
